### PR TITLE
Strong params fix for login issue

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ActiveRecord::Base
   before_create :set_sha
 
   def self.from_omniauth(auth)
-    where(auth.slice("provider", "uid")).first || create_from_omniauth(auth)
+    where(provider: auth["provider"], uid: auth["uid"] ).first || create_from_omniauth(auth)
   end
 
   def self.create_from_omniauth(auth)


### PR DESCRIPTION
Fixes #54 Was an issue with rails 4's strong_parameters policy. Slice on a untrusted hash is still untrusted which is why we where getting the Forbidden Attribute error. Login should work again 