### PR TITLE
Failing test

### DIFF
--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -375,6 +375,9 @@ describe PapersController do
     it "AS EDITOR responds successfully with a correct status and accept paper" do
       authenticate(:editor)
       paper = create(:paper, :review_completed)
+      2.times do
+        create(:annotation, paper:paper)
+      end
 
       put :transition, identifier:paper.typed_provider_id, transition: :accept
 


### PR DESCRIPTION
Demonstration of #239 bug in the tests.

This test is failing as follows:

```
  1) PapersController PUT #transition AS EDITOR responds successfully with a correct status and accept paper
     Failure/Error: put :transition, identifier:paper.typed_provider_id, transition: :accept
     AASM::InvalidTransition:
       Event 'resolve' cannot transition from 'unresolved'
     # ./app/models/paper.rb:151:in `resolve_all_issues'
     # ./app/controllers/papers_controller.rb:93:in `transition'
     # ./spec/support/controller_spec_helpers.rb:36:in `process_with_default_params'
     # ./spec/controllers/papers_controller_spec.rb:382:in `block (3 levels) in <top (required)>'
```

because [`resolve_all_issues`](https://github.com/openjournals/theoj/blob/master/app/models/paper.rb#L150-L152) on `Paper` calls `resolve` on each `Annotation`.

As the `resolve` call on `Annotation` is guarded with [`can_change_state`](https://github.com/openjournals/theoj/blob/master/app/models/annotation.rb#L79-L81) which checks to see if the paper is `under_review?` before changing the state of the annotation. This fails as the paper _isn't_ in the `under_review` state, it's `review_completed`.
