### PR TITLE
fix schema.rb so rake db:setup can complete

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,7 +51,10 @@ ActiveRecord::Schema.define(version: 20150808025904) do
   add_index "assignments", ["user_id"], name: "index_assignment_user_id", using: :btree
 
   create_table "papers", force: :cascade do |t|
+    t.integer  "user_id",           limit: 4
     t.integer  "submittor_id",      limit: 4
+    t.datetime "submitted_at"
+    t.text     "location",          limit: 1000
     t.string   "document_location", limit: 255
     t.string   "state",             limit: 255
     t.string   "title",             limit: 255


### PR DESCRIPTION
Hi, 

I cloned `theoj` and tried to run `rake db:setup`, but ran into errors for:

* submitted_at
* location
* user_id

These fields also appear to referenced in code, so I added them back to `schema.rb` so the db setup task completes successfully.